### PR TITLE
rsocket-helidon: deprecate for removal

### DIFF
--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/AbstractRSocket.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/AbstractRSocket.java
@@ -20,6 +20,8 @@ import io.helidon.common.reactive.Multi;
 import io.helidon.common.reactive.Single;
 import java.util.concurrent.Flow;
 
+/** Deprecated for removal since helidon-common-reactive project seems inactive/abandoned. */
+@Deprecated
 public abstract class AbstractRSocket implements RSocketHandler {
 
   @Override

--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/ClientAcceptor.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/ClientAcceptor.java
@@ -18,6 +18,8 @@ package com.jauntsdn.rsocket;
 
 import java.util.function.Function;
 
+/** Deprecated for removal since helidon-common-reactive project seems inactive/abandoned. */
+@Deprecated
 public interface ClientAcceptor {
 
   RSocket accept(SetupMessage setup, RSocket requesterRSocket);

--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/ClientStreamsAcceptor.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/ClientStreamsAcceptor.java
@@ -16,6 +16,8 @@
 
 package com.jauntsdn.rsocket;
 
+/** Deprecated for removal since helidon-common-reactive project seems inactive/abandoned. */
+@Deprecated
 public interface ClientStreamsAcceptor {
 
   MessageStreams accept(SetupMessage setup, MessageStreams requester);

--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/Closeable.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/Closeable.java
@@ -18,6 +18,8 @@ package com.jauntsdn.rsocket;
 
 import io.helidon.common.reactive.Single;
 
+/** Deprecated for removal since helidon-common-reactive project seems inactive/abandoned. */
+@Deprecated
 public interface Closeable extends GracefulCloseable {
 
   Single<Void> onClose();

--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/MessageStreams.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/MessageStreams.java
@@ -23,7 +23,12 @@ import java.util.Optional;
 import java.util.concurrent.Flow;
 import java.util.concurrent.ScheduledExecutorService;
 
-/** Channel interactions for async exchange of binary messages using Helidon-common-reactive API. */
+/**
+ * Deprecated for removal since helidon-common-reactive project seems inactive/abandoned.
+ *
+ * <p>Channel interactions for async exchange of binary messages using Helidon-common-reactive API.
+ */
+@Deprecated
 public interface MessageStreams extends Closeable {
 
   /**

--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/MessageStreamsHandler.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/MessageStreamsHandler.java
@@ -19,6 +19,8 @@ package com.jauntsdn.rsocket;
 import io.helidon.common.reactive.Multi;
 import java.util.concurrent.Flow;
 
+/** Deprecated for removal since helidon-common-reactive project seems inactive/abandoned. */
+@Deprecated
 public interface MessageStreamsHandler extends MessageStreams {
 
   default Multi<Message> requestChannel(Message message, Flow.Publisher<Message> messages) {

--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/RSocket.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/RSocket.java
@@ -22,9 +22,12 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
 /**
- * Models RSocket interactions as described in
+ * Deprecated for removal since helidon-common-reactive project seems inactive/abandoned.
+ *
+ * <p>Models RSocket interactions as described in
  * https://github.com/rsocket/rsocket/blob/master/Protocol.md#stream-sequences-and-lifetimes
  */
+@Deprecated
 public interface RSocket extends MessageStreams, Availability {
 
   /**

--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/RSocketHandler.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/RSocketHandler.java
@@ -16,4 +16,6 @@
 
 package com.jauntsdn.rsocket;
 
+/** Deprecated for removal since helidon-common-reactive project seems inactive/abandoned. */
+@Deprecated
 public interface RSocketHandler extends RSocket, MessageStreamsHandler {}

--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/RSocketProxy.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/RSocketProxy.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 import java.util.concurrent.Flow;
 import java.util.concurrent.ScheduledExecutorService;
 
+/** Deprecated for removal since helidon-common-reactive project seems inactive/abandoned. */
+@Deprecated
 public class RSocketProxy implements RSocket, RSocketHandler {
   protected final MessageStreams source;
 

--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/ServerAcceptor.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/ServerAcceptor.java
@@ -19,6 +19,8 @@ package com.jauntsdn.rsocket;
 import io.helidon.common.reactive.Single;
 import java.util.function.Function;
 
+/** Deprecated for removal since helidon-common-reactive project seems to be inactive/abandoned. */
+@Deprecated
 public interface ServerAcceptor {
 
   Single<RSocket> accept(SetupMessage setup, RSocket requesterRSocket);

--- a/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/ServerStreamsAcceptor.java
+++ b/rsocket-helidon/src/main/java/com/jauntsdn/rsocket/ServerStreamsAcceptor.java
@@ -18,6 +18,8 @@ package com.jauntsdn.rsocket;
 
 import io.helidon.common.reactive.Single;
 
+/** Deprecated for removal since helidon-common-reactive project seems inactive/abandoned. */
+@Deprecated
 public interface ServerStreamsAcceptor {
 
   Single<MessageStreams> accept(SetupMessage setup, MessageStreams requester);

--- a/rsocket-rpc-helidon/src/main/java/com/jauntsdn/rsocket/RpcHandler.java
+++ b/rsocket-rpc-helidon/src/main/java/com/jauntsdn/rsocket/RpcHandler.java
@@ -30,7 +30,12 @@ import java.util.concurrent.Flow;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
-/** Utility for serving multiple {@link RpcService} from single {@link MessageStreams} endpoint. */
+/**
+ * Deprecated for removal since helidon-common-reactive project seems inactive/abandoned.
+ *
+ * <p>Utility for serving multiple {@link RpcService} from single {@link MessageStreams} endpoint.
+ */
+@Deprecated
 public final class RpcHandler implements MessageStreamsHandler {
   private static final String NO_DEFAULT_ZERO_SERVICES_MESSAGE =
       "RpcHandler: no default service because 0 services registered";

--- a/rsocket-rpc-helidon/src/main/java/com/jauntsdn/rsocket/RpcInstrumentation.java
+++ b/rsocket-rpc-helidon/src/main/java/com/jauntsdn/rsocket/RpcInstrumentation.java
@@ -20,6 +20,8 @@ import io.helidon.common.reactive.Single;
 import java.util.concurrent.Flow;
 import java.util.function.Function;
 
+/** Deprecated for removal since helidon-common-reactive project seems inactive/abandoned. */
+@Deprecated
 public interface RpcInstrumentation {
 
   <T> Function<? super Flow.Publisher<T>, ? extends Flow.Publisher<T>> instrumentMulti(

--- a/rsocket-rpc-helidon/src/main/java/com/jauntsdn/rsocket/RpcService.java
+++ b/rsocket-rpc-helidon/src/main/java/com/jauntsdn/rsocket/RpcService.java
@@ -16,6 +16,8 @@
 
 package com.jauntsdn.rsocket;
 
+/** Deprecated for removal since helidon-common-reactive project seems inactive/abandoned. */
+@Deprecated
 public interface RpcService extends MessageStreamsHandler {
 
   String service();


### PR DESCRIPTION
rsocket-helidon: deprecate for removal since helidon-common-reactive project seems inactive/abandoned.